### PR TITLE
fix: social-icon images were broken on post pages

### DIFF
--- a/_includes/page_footer.html
+++ b/_includes/page_footer.html
@@ -22,7 +22,7 @@
 			    <h4>Follow us</h4>
                  {% for icon in site.data.social-icons %}
 			     <a class="social-icon--link {{ icon.class }}" href="{{ icon.url }}">
-				  <img src= "{{ icon.class | prepend: 'assets/images/' | append: '.svg' }}" alt=cyclone-project@"{{ icon.class }}" width="42">
+				  <img src= "{{ icon.class | prepend: '/assets/images/' | append: '.svg' }}" alt=cyclone-project@"{{ icon.class }}" width="42">
 			     </a>
 			     {% endfor %}
 			   </p> 


### PR DESCRIPTION
The `src` was a relative link, so that it worked only on pages at the root url. And post pages are deeper nested, e.g. `http://www.cyclone-project.eu/2015/06/30/deliverable.html`

I'm creating a PR because I don't have write rights on the repo.
